### PR TITLE
Update packages.el

### DIFF
--- a/packages.el
+++ b/packages.el
@@ -31,8 +31,7 @@
 
 (defconst fstar-packages
   '(
-    (fstar-mode :location (recipe :fetcher github
-                                  :repo "FStarLang/fstar-mode.el"))
+    (fstar-mode)
     )
   "The list of Lisp packages required by the fstar layer.
 


### PR DESCRIPTION
Source from MELPA instead of GitHub repo. Fixes missing fslit install due to not including etc/, future-proofs against similar additions/changes.